### PR TITLE
Improved and working solution.

### DIFF
--- a/mini_serv.c
+++ b/mini_serv.c
@@ -8,13 +8,13 @@
 typedef struct s_client
 {
     int     id;
-    char    msg[100000];
+    char    msg[300000];
 }   t_client;
 
 t_client    clients[1024];
 fd_set      read_set, write_set, current;
 int         maxfd = 0, gid = 0;
-char        send_buffer[120000], recv_buffer[120000];
+char        send_buffer[300000], recv_buffer[300000];
 
 void    err(char  *msg)
 {
@@ -87,6 +87,7 @@ int     main(int ac, char **av)
                         send_to_all(fd);
                         FD_CLR(fd, &current);
                         close(fd);
+                        bzero(clients[fd].msg, strlen(clients[fd].msg));
                     }
                     else
                     {


### PR DESCRIPTION
I tried it last week with the old solution and it didn't let me pass test 8.
The problem was that if a client sent a partial message and then disconnected, the partial message would still be in the buffer and the next connecting client would send that garbage with its next valid message.
And I increased the buffersize because it didn't work with the grademe tester.

Today i passed with the changes. :D