### PR TITLE
Fixed overflow issue in mini_serv.c

### DIFF
--- a/mini_serv.c
+++ b/mini_serv.c
@@ -8,7 +8,7 @@
 typedef struct s_client
 {
     int     id;
-    char    msg[300000];
+    char    msg[290000];
 }   t_client;
 
 t_client    clients[1024];


### PR DESCRIPTION
# Issue:
A potential *buffer overflow* issue exists in the main function of server.c. Specifically, the use of **sprintf** at line 100 can result in writing more data into send_buffer than it can safely hold.
```c
sprintf(send_buffer, "client %d: %s\n", clients[fd].id, clients[fd].msg);
```
The issue arises because send_buffer has a fixed size of 300,000 bytes, but the formatted output can exceed this size if clients[fd].msg approaches its maximum length. Indeed, *the formatted string "client %d: %s\n" and the client message can together exceed the buffer size*.

# steps to reproduce:
It's a simple compilation warning:
```bash
gcc server.c

warning: ‘%s’ directive writing up to 299999 bytes into a region of size between 299980 and 299990 [-Wformat-overflow=]
```
# Solution

The program should safely handle messages without risking buffer overflow. The sprintf function does not prevent potential overflow, leading to undefined behavior if a large client message is received.

> Potential solution:
Replace sprintf with **snprintf** to ensure that the buffer size is respected:
```c
snprintf(send_buffer, sizeof(send_buffer), "client %d: %s\n", clients[fd].id, clients[fd].msg);
```
However, this causes a possible truncation f it exceeds the buffer size, and could lead to another warning.

## Prefered solution:
Simply *reduce the size of the msg field* in the t_client struct to leave enough space for the formatting string and the client ID:
```c
typedef struct s_client
{
    int     id;
    char    msg[299980];  // Reduced size
}   t_client;
```